### PR TITLE
CLI: Create Cobra command skeleton with all subcommands

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var attachCmd = &cobra.Command{
+	Use:   "attach TASK_ID",
+	Short: "Connect to a running agent",
+	Long: `Connect to an existing agent's shell.
+
+If the agent is stopped, it will be started first.
+When you exit the shell, the VM continues running.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("attach not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(attachCmd)
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "View or modify global configuration",
+	Long: `View or modify the global choir configuration.
+
+Subcommands:
+  show   Print current configuration
+  edit   Open configuration in $EDITOR
+  set    Set a specific configuration key`,
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print current configuration",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("config show not implemented")
+	},
+}
+
+var configEditCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Open configuration in $EDITOR",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("config edit not implemented")
+	},
+}
+
+var configSetCmd = &cobra.Command{
+	Use:   "set KEY VALUE",
+	Short: "Set a configuration key",
+	Long: `Set a specific configuration key using dot notation.
+
+Example:
+  choir config set backends.local.memory 8GB`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		value := args[1]
+		return fmt.Errorf("config set not implemented: %s=%s", key, value)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configEditCmd)
+	configCmd.AddCommand(configSetCmd)
+}

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create a .choir.yaml template",
+	Long: `Create a .choir.yaml template in the current directory.
+
+The template includes commented examples for all configuration options.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("init not implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+
+	initCmd.Flags().Bool("force", false, "overwrite existing file")
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List agents",
+	Long: `List all agents, optionally filtered by backend or repository.
+
+By default, removed and failed agents are hidden. Use --all to show them.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("list not implemented")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	listCmd.Flags().String("backend", "", "filter by backend")
+	listCmd.Flags().Bool("repo", false, "filter by current repository")
+	listCmd.Flags().Bool("all", false, "include removed/failed agents")
+	listCmd.Flags().Bool("json", false, "output as JSON")
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs TASK_ID",
+	Short: "Show agent provisioning logs",
+	Long: `Show provisioning and setup logs for an agent.
+
+Useful for debugging failed spawns or reviewing setup command output.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("logs not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(logsCmd)
+
+	logsCmd.Flags().BoolP("follow", "f", false, "stream logs (if agent is provisioning)")
+}

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var rmCmd = &cobra.Command{
+	Use:   "rm TASK_ID",
+	Short: "Remove an agent",
+	Long: `Remove an agent and destroy its VM.
+
+If the agent is running, you will be prompted for confirmation
+unless --force is specified.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("rm not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rmCmd)
+
+	rmCmd.Flags().BoolP("force", "f", false, "remove without confirmation")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version is set at build time
+	Version = "dev"
+
+	// Global flags
+	backend string
+	verbose bool
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "choir",
+	Short: "Manage isolated VM environments for AI agents",
+	Long: `Choir manages isolated development environments ("agents") for running
+AI coding assistants in parallel. Each agent operates in its own VM with
+full filesystem and network isolation, enabling multiple concurrent
+workstreams on the same codebase without conflicts.`,
+	Version: Version,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&backend, "backend", "", "override default backend")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
+}

--- a/cmd/spawn.go
+++ b/cmd/spawn.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var spawnCmd = &cobra.Command{
+	Use:   "spawn TASK_ID",
+	Short: "Create and start a new agent",
+	Long: `Create and start a new agent with the given task ID.
+
+The agent runs in an isolated VM with a clone of the current repository
+on a dedicated branch (agent/<task-id> by default).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("spawn not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(spawnCmd)
+
+	spawnCmd.Flags().String("base", "", "base branch to spawn from")
+	spawnCmd.Flags().String("prompt", "", "initial prompt to display when agent starts")
+	spawnCmd.Flags().String("task-file", "", "file containing task description")
+	spawnCmd.Flags().Bool("rm", false, "remove agent automatically when shell exits")
+	spawnCmd.Flags().Int("cpus", 0, "override CPU allocation")
+	spawnCmd.Flags().String("memory", "", "override memory allocation")
+	spawnCmd.Flags().Bool("no-setup", false, "skip setup commands from project config")
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var startCmd = &cobra.Command{
+	Use:   "start TASK_ID",
+	Short: "Start a stopped agent",
+	Long: `Start a previously stopped agent.
+
+The agent must be in 'stopped' status.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("start not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status TASK_ID",
+	Short: "Show detailed agent status",
+	Long: `Show detailed status information for an agent.
+
+Displays task ID, backend, status, branch, base branch, repository,
+remote URL, creation time, and resource allocation.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("status not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop TASK_ID",
+	Short: "Stop a running agent",
+	Long: `Stop a running agent without removing it.
+
+The agent can be restarted later with 'choir start'.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		taskID := args[0]
+		return fmt.Errorf("stop not implemented: %s", taskID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(stopCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/Quidge/choir
+
+go 1.25.5
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/Quidge/choir/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
- Initialize Go module with Cobra CLI framework
- Create stub commands for all operations: spawn, attach, list, stop, start, rm, status, logs, init, config
- Each command validates arguments and flags but returns "not implemented" placeholder

## Test plan
- [x] `./bin/choir --help` displays all commands
- [x] `./bin/choir --version` shows version
- [x] `./bin/choir <cmd> --help` works for each command
- [x] Commands error when required args missing
- [x] Passes `go vet` and `gofmt`
- [x] Passes lefthook pre-commit checks

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)