### PR TITLE
Add local branch cleanup to merge-and-update-issues command

### DIFF
--- a/.claude/commands/merge-and-update-issues.md
+++ b/.claude/commands/merge-and-update-issues.md
@@ -14,3 +14,27 @@ Additionally, it's possible that the related GH issue is a child issue related t
 ## In case of a deviation
 
 If the PR deviated from the written design in the directly related GH issue or any parent + sibling issues, in ways that would affect those issues, those issue bodies need to be updated to note the new changes.
+
+## Local Branch Cleanup
+
+After updating issues, clean up the local branch if the PR was merged:
+
+1. **Get the PR's branch name and merge status:**
+   ```bash
+   gh pr view <pr-number> --json headRefName,state --jq '{branch: .headRefName, state: .state}'
+   ```
+
+2. **If PR was merged, switch to main and pull:**
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+3. **Delete the local branch:**
+   ```bash
+   git branch -d <pr-branch>
+   ```
+   - Use `-d` (safe delete) which only deletes if fully merged
+   - If the branch doesn't exist locally, skip this step
+
+4. **Confirm to user:** "Switched to main, pulled latest, and deleted local branch `<pr-branch>`"


### PR DESCRIPTION
## Summary

After a PR is merged, the local branch often gets left behind (as happened with `issue-7` after PR #21 was merged). This adds instructions to the `/merge-and-update-issues` command to automatically clean up:

- Switch to main and pull latest changes
- Delete the local feature branch (using safe `-d` flag)

## Why

This ensures a clean working state after completing work on an issue. Without this, old branches accumulate locally and you may accidentally continue working on a stale branch.

## Test plan

- [x] Manually verify the command file is syntactically correct
- [ ] Test by running `/merge-and-update-issues` after merging a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)