### PR TITLE
Migrate from deprecated brews to homebrew_casks in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,15 +22,21 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-brews:
+homebrew_casks:
   - repository:
       owner: Quidge
       name: homebrew-choir
       token: "{{ .Env.HOMEBREW_TAP_REPO_GH_PAT }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://github.com/Quidge/choir"
     description: "Create isolated environments for AI agents to execute autonomously"
     license: "MIT"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/choir"]
+          end
 
 release:
   github:


### PR DESCRIPTION
## Why

GoReleaser v2.10+ is phasing out the `brews` configuration, and our release workflow is already showing deprecation warnings ([see action run](https://github.com/Quidge/choir/actions/runs/20510317680/job/58930559374)). Migrating now avoids future breakage when `brews` support is removed entirely.

## Changes

- Replace `brews` with `homebrew_casks` configuration
- Update output directory from `Formula` to `Casks`
- Add post-install hook to remove macOS quarantine attributes (needed because choir binaries are not signed/notarized)

Closes #37

## Test plan
- [x] GoReleaser config validation passes (`goreleaser check`)
- [ ] Verify cask is generated correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)