### PR TITLE
Pin goreleaser-action to v2 version constraint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Using `version: latest` in the release workflow produces a warning and risks unexpected breaking changes when new major versions are released. This change pins to `~> v2`, which:

- Eliminates the `##[warning]You are using 'latest' as default version` message
- Ensures reproducible builds by staying within the v2 major version
- Follows GoReleaser's official documentation recommendations

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)