### PR TITLE
Allow relative paths for file mount targets

### DIFF
--- a/internal/config/create.go
+++ b/internal/config/create.go
@@ -2,16 +2,16 @@ package config
 
 import (
 	"fmt"
-
-	"github.com/Quidge/choir/internal/pathutil"
 )
 
-// ValidateFileMounts validates that all file mount target paths are absolute.
+// ValidateFileMounts validates file mounts.
 // Source paths are expected to be already expanded by ExpandFileMounts.
+// Target paths can be absolute or relative (relative paths are resolved
+// by backends relative to the workspace root).
 func ValidateFileMounts(files []FileMount) error {
 	for i, f := range files {
-		if err := pathutil.ValidateAbsolute(f.Target); err != nil {
-			return fmt.Errorf("file mount %d target: %w", i, err)
+		if f.Target == "" {
+			return fmt.Errorf("file mount %d: target path is required", i)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Remove overly strict validation requiring absolute paths for file mount targets
- Users can now specify relative paths (e.g., `target: config/.env`) which are resolved relative to the workspace root

## Why

The validation layer was rejecting relative paths before they reached the backend, even though the worktree backend already handled them correctly by joining with the workspace directory (`internal/backend/worktree/setup.go:128-131`).

This mismatch meant valid, intuitive configs like:

```yaml
files:
  - source: /Users/me/.config/app.toml
    target: config/app.toml  # relative to repo root
```

...were rejected with "path is not absolute" errors.

## Changes

- `ValidateFileMounts` now only requires target paths to be non-empty (empty paths are still rejected)
- Updated tests to expect relative paths to be allowed

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)