### PR TITLE
Run setup when files or env vars are configured

### DIFF
--- a/cmd/env/create.go
+++ b/cmd/env/create.go
@@ -154,7 +154,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run setup unless --no-setup is specified
-	if !noSetupFlag && len(createCfg.SetupCommands) > 0 {
+	// Setup handles environment variables, file mounts, and setup commands
+	hasSetupWork := len(createCfg.SetupCommands) > 0 ||
+		len(createCfg.Files) > 0 ||
+		len(createCfg.Environment) > 0
+	if !noSetupFlag && hasSetupWork {
 		runner := be.NewSetupRunner(backendID)
 		setupCfg := &backend.SetupConfig{
 			Environment:   createCfg.Environment,


### PR DESCRIPTION
## Summary

- Run the setup runner when there are file mounts or environment variables, not just setup commands

## Why

The setup runner handles three things:
1. Writing environment variables to `.choir-env`
2. Creating file mounts (symlinks/copies)
3. Running setup commands

But the condition to invoke it only checked for setup commands:

```go
if !noSetupFlag && len(createCfg.SetupCommands) > 0 {
```

This meant users with file mounts but no commands had to add a no-op like `"true"` just to trigger their configuration:

```yaml
setup:
  - "true"  # Workaround to trigger file mounts
```

## Changes

The condition now checks for any setup work:

```go
hasSetupWork := len(createCfg.SetupCommands) > 0 ||
    len(createCfg.Files) > 0 ||
    len(createCfg.Environment) > 0
if !noSetupFlag && hasSetupWork {
```

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)