### PR TITLE
Resolve relative source paths in file mounts

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -205,7 +205,7 @@ func TestMerge(t *testing.T) {
 		project := DefaultProjectConfig()
 		flags := FlagOverrides{}
 
-		merged, err := Merge(global, project, flags)
+		merged, err := Merge(global, project, flags, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -224,7 +224,7 @@ func TestMerge(t *testing.T) {
 		project.Resources.CPUs = 8
 		flags := FlagOverrides{}
 
-		merged, err := Merge(global, project, flags)
+		merged, err := Merge(global, project, flags, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestMerge(t *testing.T) {
 			CPUs:   16,
 		}
 
-		merged, err := Merge(global, project, flags)
+		merged, err := Merge(global, project, flags, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -262,7 +262,7 @@ func TestMerge(t *testing.T) {
 		project := DefaultProjectConfig()
 		flags := FlagOverrides{Backend: "nonexistent"}
 
-		_, err := Merge(global, project, flags)
+		_, err := Merge(global, project, flags, "")
 		if err == nil {
 			t.Error("expected error for unknown backend")
 		}


### PR DESCRIPTION
## Summary

- Resolve relative source paths in file mounts relative to the project config directory

## Why

After fixing #46 (allowing relative target paths), users could still have issues when using relative source paths. A config like:

```yaml
files:
  - source: config/.env
    target: config/.env
    readonly: true
```

Would create a symlink pointing to `config/.env` (relative) instead of `/path/to/project/config/.env` (absolute), resulting in broken symlinks.

## Changes

- `ExpandFileMounts` now takes a `baseDir` parameter and resolves relative source paths against it
- `Merge` passes the project directory to `ExpandFileMounts`
- `Load` and `LoadFromCwd` pass the project directory through to `Merge`

Related to #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)