### PR TITLE
Add `ls` alias for `choir env list` command

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/Quidge/choir/internal/backend/worktree"
 	"github.com/Quidge/choir/internal/config"
 	"github.com/Quidge/choir/internal/state"
+	"github.com/spf13/cobra"
 )
 
 // cleanGitEnv returns a clean environment without git-specific variables
@@ -525,5 +526,44 @@ func TestCobraCommands(t *testing.T) {
 	}
 	if !found {
 		t.Error("command 'env' not found in root command")
+	}
+}
+
+// TestEnvListAlias verifies that "ls" is an alias for "list".
+func TestEnvListAlias(t *testing.T) {
+	// Find the env command
+	var envCmd *cobra.Command
+	for _, cmd := range rootCmd.Commands() {
+		if strings.HasPrefix(cmd.Use, "env") {
+			envCmd = cmd
+			break
+		}
+	}
+	if envCmd == nil {
+		t.Fatal("env command not found")
+	}
+
+	// Find the list subcommand
+	var listCmd *cobra.Command
+	for _, cmd := range envCmd.Commands() {
+		if strings.HasPrefix(cmd.Use, "list") {
+			listCmd = cmd
+			break
+		}
+	}
+	if listCmd == nil {
+		t.Fatal("list command not found")
+	}
+
+	// Verify "ls" is in the aliases
+	found := false
+	for _, alias := range listCmd.Aliases {
+		if alias == "ls" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'ls' to be an alias for 'list'")
 	}
 }

--- a/cmd/env/list.go
+++ b/cmd/env/list.go
@@ -12,8 +12,9 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List environments",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List environments",
 	Long: `List all environments, optionally filtered by backend or repository.
 
 By default, removed and failed environments are hidden. Use --all to show them.`,


### PR DESCRIPTION
## Summary

- Add `ls` as an alias for `choir env list`, enabling `choir env ls` as shorthand
- Add test verifying the alias is registered

This follows Unix conventions and matches behavior of other CLI tools (Docker, Helm, GitHub CLI).

Closes #41

## Test plan

- [x] `go test ./...` passes
- [x] `go test -tags=conformance,worktree ./internal/backend/conformance` passes
- [x] `choir env ls` works as alias for `choir env list`
- [x] Flags work with alias (e.g., `choir env ls --all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)