### PR TITLE
Improve error message for ambiguous ID when hidden environments cause conflict

### DIFF
--- a/cmd/env/attach.go
+++ b/cmd/env/attach.go
@@ -39,8 +39,9 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		if errors.Is(err, state.ErrEnvironmentNotFound) {
 			return fmt.Errorf("environment %q not found", idPrefix)
 		}
-		if errors.Is(err, state.ErrAmbiguousPrefix) {
-			return fmt.Errorf("ambiguous environment ID %q: matches multiple environments", idPrefix)
+		var ambiguousErr *state.AmbiguousPrefixError
+		if errors.As(err, &ambiguousErr) {
+			return FormatAmbiguousPrefixError(ambiguousErr)
 		}
 		if errors.Is(err, state.ErrInvalidPrefix) {
 			return fmt.Errorf("invalid environment ID %q: must contain only hexadecimal characters", idPrefix)

--- a/cmd/env/errors.go
+++ b/cmd/env/errors.go
@@ -1,0 +1,46 @@
+package env
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Quidge/choir/internal/state"
+)
+
+// VisibleStatuses are the statuses shown by default in `choir env list`.
+var VisibleStatuses = []state.EnvironmentStatus{
+	state.StatusProvisioning,
+	state.StatusReady,
+}
+
+// isVisibleStatus returns true if the status is visible by default.
+func isVisibleStatus(status state.EnvironmentStatus) bool {
+	for _, s := range VisibleStatuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatAmbiguousPrefixError formats an AmbiguousPrefixError into a helpful
+// error message that shows all matching environments with their visibility status.
+func FormatAmbiguousPrefixError(err *state.AmbiguousPrefixError) error {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("ambiguous environment ID %q: matches %d environments\n", err.Prefix, len(err.Matches)))
+	sb.WriteString("\nMatching environments:\n")
+
+	for _, env := range err.Matches {
+		shortID := state.ShortID(env.ID)
+		visibility := "visible"
+		if !isVisibleStatus(env.Status) {
+			visibility = "hidden, use --all to see"
+		}
+		sb.WriteString(fmt.Sprintf("  %s  %s  (%s)\n", shortID, env.Status, visibility))
+	}
+
+	sb.WriteString("\nHint: use a longer prefix or run \"choir env list --all\" to see hidden environments")
+
+	return fmt.Errorf("%s", sb.String())
+}

--- a/cmd/env/errors_test.go
+++ b/cmd/env/errors_test.go
@@ -1,0 +1,153 @@
+package env
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Quidge/choir/internal/state"
+)
+
+func TestIsVisibleStatus(t *testing.T) {
+	tests := []struct {
+		status  state.EnvironmentStatus
+		visible bool
+	}{
+		{state.StatusProvisioning, true},
+		{state.StatusReady, true},
+		{state.StatusFailed, false},
+		{state.StatusRemoved, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if got := isVisibleStatus(tt.status); got != tt.visible {
+				t.Errorf("isVisibleStatus(%q) = %v, want %v", tt.status, got, tt.visible)
+			}
+		})
+	}
+}
+
+func TestFormatAmbiguousPrefixError(t *testing.T) {
+	now := time.Now()
+
+	t.Run("all visible", func(t *testing.T) {
+		err := &state.AmbiguousPrefixError{
+			Prefix: "abc",
+			Matches: []*state.Environment{
+				{ID: "abc123def456abc123def456abc12345", Status: state.StatusReady, CreatedAt: now},
+				{ID: "abc456def789abc456def789abc45678", Status: state.StatusProvisioning, CreatedAt: now},
+			},
+		}
+
+		formatted := FormatAmbiguousPrefixError(err)
+		msg := formatted.Error()
+
+		// Check header
+		if !strings.Contains(msg, `ambiguous environment ID "abc"`) {
+			t.Errorf("expected header with prefix, got: %s", msg)
+		}
+		if !strings.Contains(msg, "matches 2 environments") {
+			t.Errorf("expected match count, got: %s", msg)
+		}
+
+		// Check environment listings
+		if !strings.Contains(msg, "abc123def456") {
+			t.Errorf("expected first short ID, got: %s", msg)
+		}
+		if !strings.Contains(msg, "abc456def789") {
+			t.Errorf("expected second short ID, got: %s", msg)
+		}
+
+		// Check visibility labels - both should be visible
+		if strings.Count(msg, "(visible)") != 2 {
+			t.Errorf("expected 2 visible labels, got: %s", msg)
+		}
+
+		// Check hint
+		if !strings.Contains(msg, "use a longer prefix") {
+			t.Errorf("expected hint about longer prefix, got: %s", msg)
+		}
+		if !strings.Contains(msg, `choir env list --all`) {
+			t.Errorf("expected hint about --all flag, got: %s", msg)
+		}
+	})
+
+	t.Run("all hidden", func(t *testing.T) {
+		err := &state.AmbiguousPrefixError{
+			Prefix: "def",
+			Matches: []*state.Environment{
+				{ID: "def123abc456def123abc456def12345", Status: state.StatusFailed, CreatedAt: now},
+				{ID: "def456abc789def456abc789def45678", Status: state.StatusRemoved, CreatedAt: now},
+			},
+		}
+
+		formatted := FormatAmbiguousPrefixError(err)
+		msg := formatted.Error()
+
+		// Both should be hidden
+		if strings.Contains(msg, "(visible)") {
+			t.Errorf("expected no visible labels, got: %s", msg)
+		}
+		if strings.Count(msg, "hidden, use --all to see") != 2 {
+			t.Errorf("expected 2 hidden labels, got: %s", msg)
+		}
+	})
+
+	t.Run("mixed visible and hidden", func(t *testing.T) {
+		err := &state.AmbiguousPrefixError{
+			Prefix: "44",
+			Matches: []*state.Environment{
+				{ID: "440707e51272440707e51272440707e5", Status: state.StatusReady, CreatedAt: now},
+				{ID: "4406ed1dd8ba4406ed1dd8ba4406ed1d", Status: state.StatusFailed, CreatedAt: now},
+			},
+		}
+
+		formatted := FormatAmbiguousPrefixError(err)
+		msg := formatted.Error()
+
+		// Check the exact scenario from the issue
+		if !strings.Contains(msg, `ambiguous environment ID "44"`) {
+			t.Errorf("expected header with prefix, got: %s", msg)
+		}
+
+		// One visible, one hidden
+		if strings.Count(msg, "(visible)") != 1 {
+			t.Errorf("expected 1 visible label, got: %s", msg)
+		}
+		if strings.Count(msg, "hidden, use --all to see") != 1 {
+			t.Errorf("expected 1 hidden label, got: %s", msg)
+		}
+
+		// Check status is shown
+		if !strings.Contains(msg, "ready") {
+			t.Errorf("expected ready status, got: %s", msg)
+		}
+		if !strings.Contains(msg, "failed") {
+			t.Errorf("expected failed status, got: %s", msg)
+		}
+	})
+
+	t.Run("large number of matches", func(t *testing.T) {
+		matches := make([]*state.Environment, 5)
+		for i := range matches {
+			matches[i] = &state.Environment{
+				ID:        "aaa123456789012345678901234567" + string(rune('0'+i)),
+				Status:    state.StatusReady,
+				CreatedAt: now,
+			}
+		}
+
+		err := &state.AmbiguousPrefixError{
+			Prefix:  "aaa",
+			Matches: matches,
+		}
+
+		formatted := FormatAmbiguousPrefixError(err)
+		msg := formatted.Error()
+
+		if !strings.Contains(msg, "matches 5 environments") {
+			t.Errorf("expected 5 matches, got: %s", msg)
+		}
+	})
+}

--- a/cmd/env/rm.go
+++ b/cmd/env/rm.go
@@ -50,8 +50,9 @@ func runRm(cmd *cobra.Command, args []string) error {
 		if errors.Is(err, state.ErrEnvironmentNotFound) {
 			return fmt.Errorf("environment %q not found", idPrefix)
 		}
-		if errors.Is(err, state.ErrAmbiguousPrefix) {
-			return fmt.Errorf("ambiguous environment ID %q: matches multiple environments", idPrefix)
+		var ambiguousErr *state.AmbiguousPrefixError
+		if errors.As(err, &ambiguousErr) {
+			return FormatAmbiguousPrefixError(ambiguousErr)
 		}
 		if errors.Is(err, state.ErrInvalidPrefix) {
 			return fmt.Errorf("invalid environment ID %q: must contain only hexadecimal characters", idPrefix)

--- a/cmd/env/status.go
+++ b/cmd/env/status.go
@@ -34,8 +34,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		if errors.Is(err, state.ErrEnvironmentNotFound) {
 			return fmt.Errorf("environment %q not found", idPrefix)
 		}
-		if errors.Is(err, state.ErrAmbiguousPrefix) {
-			return fmt.Errorf("ambiguous environment ID %q: matches multiple environments", idPrefix)
+		var ambiguousErr *state.AmbiguousPrefixError
+		if errors.As(err, &ambiguousErr) {
+			return FormatAmbiguousPrefixError(ambiguousErr)
 		}
 		if errors.Is(err, state.ErrInvalidPrefix) {
 			return fmt.Errorf("invalid environment ID %q: must contain only hexadecimal characters", idPrefix)


### PR DESCRIPTION
## Summary

When users encounter an "ambiguous environment ID" error, they often see only one matching environment in `choir env list` because failed/removed environments are hidden by default. This creates a confusing experience where the error message doesn't match what they can see.

This PR improves the error message to show all matching environments with their visibility status, helping users understand why the ambiguity exists and how to resolve it.

**New error output:**
```
Error: ambiguous environment ID "44": matches 2 environments

Matching environments:
  440707e51272  ready   (visible)
  4406ed1dd8ba  failed  (hidden, use --all to see)

Hint: use a longer prefix or run "choir env list --all" to see hidden environments
```

### Implementation notes

Minor deviation from issue: Named the error type `AmbiguousPrefixError` instead of `ErrAmbiguousPrefixWithMatches` to follow Go conventions (error types are typically named `XxxError`).

Closes #66

## Test plan

- [x] Unit test: `GetEnvironmentByPrefix` returns error with match details when ambiguous
- [x] Unit test: Error formatting includes all matching environments with correct visible/hidden labels
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)