### PR TITLE
Enable per-worktree git config isolation

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -292,6 +292,26 @@ git push origin env/a1b2c3d4
 gh pr create --base main
 ```
 
+### Per-Environment Git Config
+
+Choir automatically enables Git's `extensions.worktreeConfig` feature (Git 2.20+) when creating environments. This allows you to set git configuration that only applies to a specific environment without affecting the main repository.
+
+Use the `--worktree` flag when setting git config inside an environment:
+
+```bash
+# Inside an environment worktree
+git config --worktree user.name "Agent Name"
+git config --worktree user.email "agent@example.com"
+
+# These settings only apply to this worktree
+# The main repo and other environments are unaffected
+```
+
+This is useful when:
+- Running automated agents that need different commit attribution
+- Testing with different git identities
+- Preventing test configuration from polluting your main repository
+
 ## Configuration
 
 ### Project Configuration

--- a/internal/backend/conformance/worktree_test.go
+++ b/internal/backend/conformance/worktree_test.go
@@ -3,13 +3,16 @@
 package conformance
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/Quidge/choir/internal/backend"
 	_ "github.com/Quidge/choir/internal/backend/worktree" // Register worktree backend
 )
 
-// TestWorktreeConformance runs the conformance test suite against the worktree backend.
+// TestWorktreeConformance runs the conformance test suite against the worktree backend,
+// followed by worktree-specific tests.
 //
 // Run with: go test -tags=conformance,worktree ./internal/backend/conformance
 func TestWorktreeConformance(t *testing.T) {
@@ -29,5 +32,75 @@ func TestWorktreeConformance(t *testing.T) {
 		BackendType: "worktree",
 		RepoSetup:   SetupGitRepo,
 	}
+
+	// Run generic Backend interface conformance tests
 	suite.Run(t)
+
+	// Run worktree-specific tests (not part of generic Backend interface)
+	t.Run("WorktreeSpecific", func(t *testing.T) {
+		testConfigIsolation(t, be)
+	})
+}
+
+// testConfigIsolation verifies that the worktree backend enables
+// extensions.worktreeConfig, allowing per-worktree git configuration that
+// doesn't pollute the main repository's .git/config.
+func testConfigIsolation(t *testing.T, be backend.Backend) {
+	repoPath := SetupGitRepo(t)
+	env := NewTestEnv(t, be, repoPath, TestEnvConfig{BackendType: "worktree"})
+
+	t.Run("ExtensionEnabled", func(t *testing.T) {
+		// Verify extensions.worktreeConfig is enabled on the main repo
+		cmd := exec.Command("git", "config", "--get", "extensions.worktreeConfig")
+		cmd.Dir = repoPath
+		cmd.Env = cleanGitEnv()
+		output, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("extensions.worktreeConfig not set on main repo: %v", err)
+		}
+		if strings.TrimSpace(string(output)) != "true" {
+			t.Errorf("expected extensions.worktreeConfig=true, got %q", strings.TrimSpace(string(output)))
+		}
+	})
+
+	t.Run("ConfigIsolation", func(t *testing.T) {
+		// Get original user.name from main repo
+		cmd := exec.Command("git", "config", "--get", "user.name")
+		cmd.Dir = repoPath
+		cmd.Env = cleanGitEnv()
+		originalOutput, _ := cmd.Output()
+		originalName := strings.TrimSpace(string(originalOutput))
+
+		// Set a different user.name in the worktree using --worktree flag
+		testName := "Conformance Test Agent"
+		cmd = exec.Command("git", "config", "--worktree", "user.name", testName)
+		cmd.Dir = env.BackendID
+		cmd.Env = cleanGitEnv()
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to set worktree config: %v\n%s", err, out)
+		}
+
+		// Verify worktree has the new config
+		cmd = exec.Command("git", "config", "--get", "user.name")
+		cmd.Dir = env.BackendID
+		cmd.Env = cleanGitEnv()
+		worktreeOutput, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("failed to get worktree user.name: %v", err)
+		}
+		if strings.TrimSpace(string(worktreeOutput)) != testName {
+			t.Errorf("worktree user.name: got %q, want %q", strings.TrimSpace(string(worktreeOutput)), testName)
+		}
+
+		// Verify main repo is unchanged (isolation works)
+		cmd = exec.Command("git", "config", "--get", "user.name")
+		cmd.Dir = repoPath
+		cmd.Env = cleanGitEnv()
+		mainOutput, _ := cmd.Output()
+		mainName := strings.TrimSpace(string(mainOutput))
+
+		if mainName != originalName {
+			t.Errorf("main repo user.name changed from %q to %q - config isolation failed", originalName, mainName)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Enable `extensions.worktreeConfig` on main repo when creating worktrees
- Add documentation for using `git config --worktree` in environments
- Add tests verifying config isolation works correctly

This prevents git config set in worktrees from polluting the main repository's `.git/config`. The issue was discovered when commits in the choir repo started being attributed to "Test User <test@example.com>" instead of the actual developer.

## Why existing tests don't use --worktree

The issue's test plan mentioned "Run worktree tests with `--worktree` config isolation to prevent test pollution." However, existing tests that call `git config user.name` do NOT need the `--worktree` flag because:

1. **Tests use isolated temp directories** - Each test creates a fresh git repo in a temp directory (`t.TempDir()`) that is automatically cleaned up
2. **Config is set on the test repo, not worktrees** - The `setupTestRepo()` helper sets `user.name` and `user.email` on the main test repo so it can make commits during setup
3. **No cross-contamination possible** - These temp repos are completely separate from the real choir repo or any other repo on the system

The new tests (`TestWorktreeConfigExtensionEnabled` and `TestWorktreeConfigIsolation`) verify that the isolation feature works correctly when users create real worktrees.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -tags=conformance,worktree ./internal/backend/conformance` passes
- [x] New test verifies `extensions.worktreeConfig` is enabled after worktree creation
- [x] New test verifies `git config --worktree` isolates config from main repo

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)