### PR TITLE
Add --attach flag to choir env create

### DIFF
--- a/cmd/env/create.go
+++ b/cmd/env/create.go
@@ -31,12 +31,14 @@ var (
 	baseFlag    string
 	backendFlag string
 	noSetupFlag bool
+	attachFlag  bool
 )
 
 func init() {
 	createCmd.Flags().StringVar(&baseFlag, "base", "", "base branch to create from (default: current branch)")
 	createCmd.Flags().StringVar(&backendFlag, "backend", "", "override default backend")
 	createCmd.Flags().BoolVar(&noSetupFlag, "no-setup", false, "skip setup commands from project config")
+	createCmd.Flags().BoolVar(&attachFlag, "attach", false, "enter the environment shell after creation")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -178,8 +180,14 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update environment status: %w", err)
 	}
 
-	// Print just the short ID for scripting
-	fmt.Println(shortID)
+	if attachFlag {
+		if err := be.Shell(ctx, backendID); err != nil {
+			return fmt.Errorf("shell exited with error: %w", err)
+		}
+	} else {
+		// Print just the short ID for scripting
+		fmt.Println(shortID)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Add `--attach` flag to `choir env create` that enters the shell immediately after creation.

## Why

The two-step workflow of creating an environment and then attaching to it is cumbersome for interactive use - it requires capturing the ID in a variable or copy-pasting it:

```bash
id=$(choir env create)
choir env attach $id
```

The `--attach` flag eliminates this friction by combining both operations into a single command:

```bash
choir env create --attach
```

When `--attach` is used, the shell is entered silently (no ID printed). Without the flag, behavior is unchanged.

## Implementation approach

This PR implements the **quick/blocking approach** from issue #63: the command blocks while the environment is created, then enters the shell once it reaches `StatusReady`. This is appropriate for the worktree backend where creation is near-instant.

Spinner/progress UI for slow backends (e.g., VMs) is deferred to a separate issue as noted in #63.

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./...` succeeds
- [x] `choir env create --help` shows the new flag
- [x] Manual test: `choir env create --attach` enters shell immediately, `exit` returns cleanly

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)